### PR TITLE
Preserve transcription deduplication across flushes

### DIFF
--- a/src/injector.py
+++ b/src/injector.py
@@ -62,7 +62,6 @@ class TextInjector(FrameProcessor):
             if text:
                 self._inject_text(text + " ")
         self._buffer = []
-        self._last_injected = ""
 
     def _inject_text(self, text: str):
         if not HAS_GUI:

--- a/tests/test_injector.py
+++ b/tests/test_injector.py
@@ -2,7 +2,12 @@ import unittest
 from unittest.mock import MagicMock, patch
 import asyncio
 from src.injector import TextInjector
-from pipecat.frames.frames import TranscriptionFrame, InterimTranscriptionFrame, TextFrame
+from pipecat.frames.frames import (
+    TranscriptionFrame,
+    InterimTranscriptionFrame,
+    TextFrame,
+    EndFrame,
+)
 
 class TestInjector(unittest.TestCase):
     def test_injection(self):
@@ -32,3 +37,33 @@ class TestInjector(unittest.TestCase):
             # It should log
             # mock_logger.debug.assert_called() # Or info
             pass
+
+    def test_deduplication_survives_flush(self):
+        injector = TextInjector(inject_immediately=False)
+        injected_texts = []
+
+        def mock_write(text):
+            injected_texts.append(text)
+
+        with patch("src.injector.HAS_GUI", True), patch("src.injector.keyboard") as mock_kb:
+            mock_kb.write = mock_write
+
+            async def run():
+                frame = TranscriptionFrame(
+                    text="hello world", user_id="user", timestamp="now"
+                )
+                await injector.process_frame(frame, MagicMock())
+
+                # First flush injects buffered text
+                await injector.process_frame(EndFrame(), MagicMock())
+
+                # Late/duplicate frame after flush should be deduplicated
+                late_frame = TranscriptionFrame(
+                    text="hello world", user_id="user", timestamp="later"
+                )
+                await injector.process_frame(late_frame, MagicMock())
+                await injector.process_frame(EndFrame(), MagicMock())
+
+            asyncio.run(run())
+
+        self.assertEqual(injected_texts, ["hello world "])


### PR DESCRIPTION
## Summary
- avoid resetting the injector's last-injected text when flushing buffered transcripts so deduplication persists after turn boundaries
- add a regression test ensuring late duplicate transcription frames are not reinjected after a flush

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d240a79c88328ac396dd10d0f844a)