### PR TITLE
Stabilize voice enrollment capture test

### DIFF
--- a/tests/test_speaker_enrollment.py
+++ b/tests/test_speaker_enrollment.py
@@ -55,6 +55,9 @@ def test_voice_enrollment_capture_is_bounded_and_clearable() -> None:
     )
 
     capture.start("test-pipe")
+    assert capture._thread is not None
+    capture._thread.join(timeout=1)
+    assert not capture._thread.is_alive()
     snapshot = capture.stop()
 
     assert snapshot["frames"] == 2


### PR DESCRIPTION
Wait for the bounded capture reader to reach EOF before stopping it. This removes the race that intermittently observed only one of two buffered frames in the release gate. Product behavior is unchanged.