### PR TITLE
Improve summary detail layout

### DIFF
--- a/Frontend/client/src/index.css
+++ b/Frontend/client/src/index.css
@@ -4031,7 +4031,6 @@ html:has(body[data-scroll-locked]) {
 @media (min-width: 1440px) {
   .transcript-detail-header-shell.has-summary-toc {
     max-width: 1320px;
-    padding-left: 296px;
   }
 
   .transcript-detail-shell.has-summary-toc {
@@ -4053,9 +4052,9 @@ html:has(body[data-scroll-locked]) {
 
   .transcript-detail-shell.has-summary-toc .summary-toc {
     position: sticky;
-    top: 84px;
+    top: 7rem;
     display: block;
-    max-height: calc(100dvh - 174px);
+    max-height: calc(100dvh - 9rem);
     overflow-y: auto;
     overscroll-behavior: contain;
     padding: 0.25rem 0.55rem 0.5rem 0;

--- a/Frontend/client/src/pages/TranscriptDetail.tsx
+++ b/Frontend/client/src/pages/TranscriptDetail.tsx
@@ -695,6 +695,26 @@ export default function TranscriptDetail() {
           </div>
 
           <div className="flex shrink-0 items-center gap-2">
+            {youtubeSourceUrl && (
+              <Button asChild variant="outline" size="sm" className="hidden md:inline-flex">
+                <a
+                  href={youtubeSourceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={t("Open on YouTube")}
+                  onClick={(event) => {
+                    if (!isTauriRuntime()) return;
+                    event.preventDefault();
+                    void openYoutubeSourceUrl(youtubeSourceUrl);
+                  }}
+                  data-testid="youtube-source-link"
+                >
+                  <Youtube className="text-red-600 dark:text-red-400" aria-hidden="true" />
+                  <span className="hidden 2xl:inline">{t("Open on YouTube")}</span>
+                  <ExternalLink className="hidden 2xl:block" aria-hidden="true" />
+                </a>
+              </Button>
+            )}
             {transcript.content && (
               <Button
                 variant="default"
@@ -764,6 +784,24 @@ export default function TranscriptDetail() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
+                {youtubeSourceUrl && (
+                  <DropdownMenuItem asChild>
+                    <a
+                      href={youtubeSourceUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={(event) => {
+                        if (!isTauriRuntime()) return;
+                        event.preventDefault();
+                        void openYoutubeSourceUrl(youtubeSourceUrl);
+                      }}
+                    >
+                      <Youtube className="mr-2 h-4 w-4 text-red-600 dark:text-red-400" aria-hidden="true" />
+                      {t("Open on YouTube")}
+                      <ExternalLink className="ml-auto h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+                    </a>
+                  </DropdownMenuItem>
+                )}
                 {transcript.content && (
                   <DropdownMenuItem onClick={handleCopyTranscript}>
                     <Copy className="w-4 h-4 mr-2" /> {t("Copy transcript")}
@@ -827,27 +865,6 @@ export default function TranscriptDetail() {
             showSummaryToc ? "transcript-detail-shell has-summary-toc space-y-6" : "transcript-detail-shell space-y-6"
           }
         >
-          {youtubeSourceUrl && (
-            <div className="flex flex-wrap items-center gap-2 pb-2">
-              <a
-                href={youtubeSourceUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="neu-button inline-flex min-h-7 items-center gap-1.5 rounded-full border border-border/60 px-3 py-1 text-xs font-medium text-muted-foreground no-underline outline-none transition-colors duration-[var(--duration-quick)] ease-[var(--ease-smooth-out)] hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transition-none"
-                onClick={(event) => {
-                  if (!isTauriRuntime()) return;
-                  event.preventDefault();
-                  void openYoutubeSourceUrl(youtubeSourceUrl);
-                }}
-                data-testid="youtube-source-link"
-              >
-                <Youtube className="h-3.5 w-3.5 text-red-600 dark:text-red-400" aria-hidden="true" />
-                {t("Open on YouTube")}
-                <ExternalLink className="h-3 w-3" aria-hidden="true" />
-              </a>
-            </div>
-          )}
-
           {transcriptQuery.isError && (
             <QueryErrorState
               title={t("Could not load transcript")}

--- a/scripts/smoke_frontend_browser.py
+++ b/scripts/smoke_frontend_browser.py
@@ -57,7 +57,6 @@ ROUTE_EXPECTATIONS: dict[str, list[str]] = {
     "/transcript/youtube-processing-smoke": [
         "Synthetic YouTube Processing",
         "Synthetic completed summary after YouTube processing.",
-        "Open on YouTube",
         "Transcript",
     ],
     "/transcript/mic-no-summary-smoke": [
@@ -5787,13 +5786,26 @@ async def exercise_transcript_processing_refresh(cdp: CdpClient, *, timeout_sec:
         expression=r"""
 (() => {
   const text = document.body ? document.body.innerText : '';
+  const youtubeLink = document.querySelector('a[data-testid="youtube-source-link"]');
+  const youtubeLinkStyle = youtubeLink ? getComputedStyle(youtubeLink) : null;
+  const youtubeLinkRect = youtubeLink ? youtubeLink.getBoundingClientRect() : null;
+  const youtubeLinkVisible = !!youtubeLink
+    && youtubeLinkStyle?.display !== 'none'
+    && youtubeLinkStyle?.visibility !== 'hidden'
+    && Number(youtubeLinkRect?.width || 0) > 0
+    && Number(youtubeLinkRect?.height || 0) > 0;
+  const youtubeLinkLabel = youtubeLink?.getAttribute('aria-label') || '';
   return {
     ok: text.includes('Synthetic completed summary after YouTube processing.')
       && !text.includes('Download complete')
-      && !text.includes('Elapsed:'),
+      && !text.includes('Elapsed:')
+      && youtubeLinkVisible
+      && youtubeLinkLabel === 'Open on YouTube',
     hasCompletedSummary: text.includes('Synthetic completed summary after YouTube processing.'),
     hasStaleDownloadStep: text.includes('Download complete'),
     hasProcessingElapsed: text.includes('Elapsed:'),
+    youtubeLinkVisible,
+    youtubeLinkLabel,
     route: window.location.pathname
   };
 })()


### PR DESCRIPTION
## Summary

- align the transcript title with the full summary layout instead of offsetting it to the content column
- move the YouTube source action into the sticky header, with compact responsive and mobile-menu variants
- keep the summary table of contents at its final sticky position from the initial render

## Why

The summary-specific header padding left an unnecessary empty column and reduced the available title width. The standalone YouTube source link also sat above the summary grid, so the table of contents shifted upward before reaching its sticky offset.

## User impact

Summary pages use the available horizontal space more effectively, source actions stay grouped together, and the table of contents no longer moves when scrolling begins.

## Validation

- `npm run check`
- `npm run test` — 84 library tests and 35 component tests passed
- `npm run test:i18n`
- Prettier and `git diff --check`
- visual browser checks at 2048 px and the 1440 px breakpoint
- verified the table of contents had the same measured Y position before and after 420 px of scrolling