### PR TITLE
refactor(ui): polish shared interface primitives

### DIFF
--- a/Frontend/client/src/components/page-intro.tsx
+++ b/Frontend/client/src/components/page-intro.tsx
@@ -35,29 +35,27 @@ export function PageIntro({
         className,
       )}
     >
-      <div className="min-w-0">
-        <div className="mb-3 flex min-w-0 items-center gap-2.5 pt-1 text-ui-micro font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-          <span className={cn("h-px w-7 shrink-0", accentClassName)} aria-hidden="true" />
-          <span>{eyebrow}</span>
+      <div className={cn("grid min-w-0 gap-4", actions && "md:grid-cols-[minmax(0,1fr)_auto] md:items-start")}>
+        <div className="min-w-0">
+          <div className="mb-3 flex min-w-0 items-center gap-2.5 pt-1 text-ui-micro font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            <span className={cn("h-px w-7 shrink-0", accentClassName)} aria-hidden="true" />
+            <span className="break-words text-pretty">{eyebrow}</span>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+            <h1 className="break-words text-balance font-heading text-[36px] font-semibold leading-[0.96] tracking-[-0.045em] text-foreground md:text-[42px]">
+              {title}
+            </h1>
+            {titleAccessory ? <div className="shrink-0">{titleAccessory}</div> : null}
+          </div>
+
+          <p className="mt-3 max-w-[72ch] break-words text-pretty text-[14px] leading-[1.55] text-muted-foreground">
+            {description}
+          </p>
         </div>
 
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-          <h1 className="text-balance font-heading text-[36px] font-semibold leading-[0.96] tracking-[-0.045em] text-foreground md:text-[42px]">
-            {title}
-          </h1>
-          {titleAccessory ? <div className="shrink-0">{titleAccessory}</div> : null}
-        </div>
-
-        <p className="mt-3 max-w-[72ch] text-pretty text-[13px] leading-5 text-muted-foreground md:text-[13.5px]">
-          {description}
-        </p>
+        {actions ? <div className="flex flex-wrap items-center gap-2 md:justify-end">{actions}</div> : null}
       </div>
-
-      {actions ? (
-        <div className="mt-4 flex flex-wrap items-center gap-2 md:absolute md:right-1 md:top-1 md:mt-0 md:justify-end">
-          {actions}
-        </div>
-      ) : null}
 
       {bottomContent ? <div className="mt-5 border-t border-border/55 py-2.5">{bottomContent}</div> : null}
     </header>

--- a/Frontend/client/src/components/page-intro.tsx
+++ b/Frontend/client/src/components/page-intro.tsx
@@ -49,7 +49,7 @@ export function PageIntro({
             {titleAccessory ? <div className="shrink-0">{titleAccessory}</div> : null}
           </div>
 
-          <p className="mt-3 max-w-[72ch] break-words text-pretty text-[14px] leading-[1.55] text-muted-foreground">
+          <p className="mt-3 max-w-[72ch] text-pretty text-[13px] break-words leading-[1.55] text-muted-foreground md:text-[14px]">
             {description}
           </p>
         </div>

--- a/Frontend/client/src/components/ui/badge.tsx
+++ b/Frontend/client/src/components/ui/badge.tsx
@@ -4,24 +4,14 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  // @replit
-  // Whitespace-nowrap: Badges should never wrap.
-  "whitespace-nowrap inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2" +
-    " hover-elevate ",
+  "inline-flex w-fit shrink-0 items-center gap-1 whitespace-nowrap rounded-md border px-2.5 py-0.5 text-xs font-semibold tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background [&>svg]:pointer-events-none [&>svg]:size-3 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
-        default:
-          // @replit shadow-xs instead of shadow, no hover because we use hover-elevate
-          "border-transparent bg-primary text-primary-foreground shadow-xs",
-        secondary:
-          // @replit no hover because we use hover-elevate
-          "border-transparent bg-secondary text-secondary-foreground",
-        destructive:
-          // @replit shadow-xs instead of shadow, no hover because we use hover-elevate
-          "border-transparent bg-destructive text-destructive-foreground shadow-xs",
-        // @replit shadow-xs" - use badge outline variable
-        outline: "text-foreground border [border-color:var(--badge-outline)]",
+        default: "border-transparent bg-primary text-primary-foreground shadow-xs",
+        secondary: "border-transparent bg-secondary text-secondary-foreground",
+        destructive: "border-transparent bg-destructive text-destructive-foreground shadow-xs",
+        outline: "border text-foreground [border-color:var(--badge-outline)]",
       },
     },
     defaultVariants: {

--- a/Frontend/client/src/components/ui/button.tsx
+++ b/Frontend/client/src/components/ui/button.tsx
@@ -5,29 +5,19 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors duration-[var(--duration-quick)] ease-[var(--ease-smooth-out)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0" +
+  "ui-pressable ui-hit-target inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,background-color,border-color,box-shadow,transform] duration-[var(--duration-quick)] ease-[var(--ease-smooth-out)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 aria-disabled:cursor-not-allowed aria-disabled:opacity-50 motion-reduce:transform-none motion-reduce:transition-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0" +
     " hover-elevate active-elevate-2",
   {
     variants: {
       variant: {
-        default:
-          // @replit: no hover, and add primary border
-          "bg-primary text-primary-foreground border border-primary-border",
-        destructive: "bg-destructive text-destructive-foreground shadow-sm border-destructive-border",
-        outline:
-          // @replit Shows the background color of whatever card / sidebar / accent background it is inside of.
-          // Inherits the current text color. Uses shadow-xs. no shadow on active
-          // No hover state
-          " border [border-color:var(--button-outline)] shadow-xs active:shadow-none ",
-        secondary:
-          // @replit border, no hover, no shadow, secondary border.
-          "border bg-secondary text-secondary-foreground border border-secondary-border ",
-        // @replit no hover, transparent border
+        default: "border border-primary-border bg-primary text-primary-foreground",
+        destructive: "border border-destructive-border bg-destructive text-destructive-foreground shadow-sm",
+        outline: "border [border-color:var(--button-outline)] shadow-xs active:shadow-none",
+        secondary: "border border-secondary-border bg-secondary text-secondary-foreground",
         ghost: "border border-transparent",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "border border-transparent text-primary underline-offset-4 ui-hover-underline",
       },
       size: {
-        // @replit changed sizes
         default: "min-h-9 px-4 py-2",
         sm: "min-h-8 rounded-md px-3 text-xs",
         lg: "min-h-10 rounded-md px-8",

--- a/Frontend/client/src/components/ui/card.tsx
+++ b/Frontend/client/src/components/ui/card.tsx
@@ -16,14 +16,22 @@ CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("font-semibold leading-none tracking-tight", className)} {...props} />
+    <div
+      ref={ref}
+      className={cn("break-words text-balance font-semibold leading-snug tracking-tight", className)}
+      {...props}
+    />
   ),
 );
 CardTitle.displayName = "CardTitle";
 
 const CardDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+    <div
+      ref={ref}
+      className={cn("break-words text-pretty text-sm leading-relaxed text-muted-foreground", className)}
+      {...props}
+    />
   ),
 );
 CardDescription.displayName = "CardDescription";

--- a/Frontend/client/src/components/ui/copy-action-button.tsx
+++ b/Frontend/client/src/components/ui/copy-action-button.tsx
@@ -20,6 +20,7 @@ export function CopyActionButton({
   onClick,
   disabled = false,
   copied = false,
+  title,
   label = "Copy",
   copiedLabel = "Copied",
   ariaLabel,
@@ -32,12 +33,18 @@ export function CopyActionButton({
   return (
     <button
       type="button"
-      className={cn("copy-pill", size === "sm" && "copy-pill--sm", copied && "is-copied", className)}
+      className={cn(
+        "copy-pill ui-pressable ui-hit-target",
+        size === "sm" && "copy-pill--sm",
+        copied && "is-copied",
+        className,
+      )}
       onClick={onClick}
       onKeyDown={(event) => event.stopPropagation()}
       disabled={disabled}
       data-label={hoverLabel}
-      aria-label={ariaLabel}
+      title={title}
+      aria-label={copied ? t(copiedLabel) : ariaLabel}
     >
       <TransitionIcon
         state={copied ? "b" : "a"}

--- a/Frontend/client/src/components/ui/delete-action-button.tsx
+++ b/Frontend/client/src/components/ui/delete-action-button.tsx
@@ -19,6 +19,7 @@ export function DeleteActionButton({
   onClick,
   disabled = false,
   loading = false,
+  title,
   label = "Delete",
   ariaLabel,
   size = "md",
@@ -28,12 +29,14 @@ export function DeleteActionButton({
   return (
     <button
       type="button"
-      className={cn("delete-pill", size === "sm" && "delete-pill--sm", className)}
+      className={cn("delete-pill ui-pressable ui-hit-target", size === "sm" && "delete-pill--sm", className)}
       onClick={onClick}
       onKeyDown={(event) => event.stopPropagation()}
       disabled={disabled}
       data-label={t(label)}
+      title={title}
       aria-label={ariaLabel}
+      aria-busy={loading || undefined}
     >
       {loading ? <WavePhysicsLoader size="micro" /> : <Trash2 className="delete-pill__icon" strokeWidth={2.1} />}
     </button>

--- a/Frontend/client/src/components/ui/input.tsx
+++ b/Frontend/client/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "ui-field ui-hover-field flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:aria-invalid:ring-destructive/40",
           className,
         )}
         ref={ref}

--- a/Frontend/client/src/components/ui/interface-primitives.test.tsx
+++ b/Frontend/client/src/components/ui/interface-primitives.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PageIntro } from "@/components/page-intro";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CardDescription, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Toggle } from "@/components/ui/toggle";
+
+describe("interface primitives", () => {
+  it("shares visible focus and target-size contracts across pressable controls", () => {
+    render(
+      <>
+        <Button aria-label="Start recording" size="icon">
+          <span aria-hidden="true">R</span>
+        </Button>
+        <Toggle aria-label="Grid view">Grid</Toggle>
+      </>,
+    );
+
+    for (const control of screen.getAllByRole("button")) {
+      expect(control).toHaveClass("ui-pressable", "ui-hit-target");
+      expect(control.className).toContain("focus-visible:ring-2");
+      expect(control.className).toContain("focus-visible:ring-offset-2");
+    }
+  });
+
+  it("keeps invalid fields explicit without replacing the native aria state", () => {
+    render(
+      <>
+        <Input aria-label="API key" aria-invalid="true" />
+        <Textarea aria-label="Prompt" aria-invalid="true" />
+      </>,
+    );
+
+    for (const field of [
+      screen.getByRole("textbox", { name: "API key" }),
+      screen.getByRole("textbox", { name: "Prompt" }),
+    ]) {
+      expect(field).toHaveAttribute("aria-invalid", "true");
+      expect(field).toHaveClass("ui-field", "ui-hover-field");
+      expect(field.className).toContain("aria-invalid:border-destructive");
+    }
+  });
+
+  it("keeps page titles and actions in a non-overlapping responsive grid", () => {
+    render(
+      <PageIntro
+        eyebrow="Workspace"
+        title="A long title that still needs room for actions"
+        description="The description should remain readable while actions occupy their own grid column."
+        sticky={false}
+        actions={<Button>Refresh</Button>}
+      />,
+    );
+
+    const header = document.querySelector('[data-page-intro="true"]');
+    const layout = header?.firstElementChild;
+
+    expect(layout).toHaveClass("grid");
+    expect(layout?.className).toContain("md:grid-cols-[minmax(0,1fr)_auto]");
+    expect(screen.getByRole("heading", { level: 1 })).toHaveClass("text-balance", "break-words");
+    expect(screen.getByText(/The description/)).toHaveClass("text-pretty", "text-[14px]");
+  });
+
+  it("wraps card copy safely and keeps passive badges visually quiet", () => {
+    render(
+      <>
+        <CardTitle>Very long provider model identifier that must wrap safely</CardTitle>
+        <CardDescription>Descriptive copy should wrap naturally without breaking the card layout.</CardDescription>
+        <Badge>12345</Badge>
+      </>,
+    );
+
+    expect(screen.getByText(/Very long provider/)).toHaveClass("text-balance", "break-words");
+    expect(screen.getByText(/Descriptive copy/)).toHaveClass("text-pretty", "break-words");
+
+    const badge = screen.getByText("12345");
+    expect(badge).toHaveClass("tabular-nums");
+    expect(badge).not.toHaveClass("hover-elevate");
+  });
+});

--- a/Frontend/client/src/components/ui/interface-primitives.test.tsx
+++ b/Frontend/client/src/components/ui/interface-primitives.test.tsx
@@ -62,7 +62,12 @@ describe("interface primitives", () => {
     expect(layout).toHaveClass("grid");
     expect(layout?.className).toContain("md:grid-cols-[minmax(0,1fr)_auto]");
     expect(screen.getByRole("heading", { level: 1 })).toHaveClass("text-balance", "break-words");
-    expect(screen.getByText(/The description/)).toHaveClass("text-pretty", "text-[14px]");
+    expect(screen.getByText(/The description/)).toHaveClass(
+      "break-words",
+      "text-pretty",
+      "text-[13px]",
+      "md:text-[14px]",
+    );
   });
 
   it("wraps card copy safely and keeps passive badges visually quiet", () => {

--- a/Frontend/client/src/components/ui/textarea.tsx
+++ b/Frontend/client/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"tex
     return (
       <textarea
         className={cn(
-          "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "ui-field ui-hover-field flex min-h-[80px] w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:aria-invalid:ring-destructive/40",
           className,
         )}
         ref={ref}

--- a/Frontend/client/src/components/ui/toggle.tsx
+++ b/Frontend/client/src/components/ui/toggle.tsx
@@ -5,17 +5,17 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const toggleVariants = cva(
-  "neu-nav-item ui-selection-toggle inline-flex items-center justify-center gap-2 rounded-xl border border-transparent text-sm font-medium transition-[background-color,color,box-shadow,transform] hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:text-foreground active:scale-[0.98] [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "ui-pressable ui-hit-target ui-selection-toggle inline-flex items-center justify-center gap-2 rounded-xl border border-transparent text-sm font-medium transition-[color,background-color,border-color,box-shadow,transform] duration-[var(--duration-quick)] ease-[var(--ease-smooth-out)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 data-[state=on]:text-foreground motion-reduce:transform-none motion-reduce:transition-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-transparent",
-        outline: "border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground",
+        default: "bg-transparent ui-hover-muted",
+        outline: "border border-input bg-transparent shadow-sm ui-hover-accent",
       },
       size: {
-        default: "h-9 px-2 min-w-9",
-        sm: "h-8 px-1.5 min-w-8",
-        lg: "h-10 px-2.5 min-w-10",
+        default: "h-9 min-w-9 px-2",
+        sm: "h-8 min-w-8 px-1.5",
+        lg: "h-10 min-w-10 px-2.5",
       },
     },
     defaultVariants: {

--- a/Frontend/client/src/interface-polish.css
+++ b/Frontend/client/src/interface-polish.css
@@ -1,0 +1,101 @@
+/*
+ * Cross-page refinements inspired by the Interfaces.dev checklist.
+ * This file is loaded after index.css so shared primitives can improve
+ * without coupling page-specific visual systems back into the global sheet.
+ */
+
+:where(h1, h2, h3, h4) {
+  overflow-wrap: anywhere;
+  text-wrap: balance;
+}
+
+:where(a) {
+  text-decoration-skip-ink: auto;
+  text-decoration-thickness: from-font;
+  text-underline-offset: 0.14em;
+}
+
+:where(time, [role="timer"], [data-ui-numeric="true"], .settings-page) {
+  font-variant-numeric: tabular-nums;
+}
+
+:where([data-ui-long-value="true"]) {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.ui-pressable {
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.ui-hit-target {
+  min-width: 40px;
+  min-height: 40px;
+}
+
+.ui-field {
+  min-height: 40px;
+  transition:
+    border-color var(--duration-quick) var(--ease-smooth-out),
+    background-color var(--duration-quick) var(--ease-smooth-out),
+    box-shadow var(--duration-quick) var(--ease-smooth-out);
+}
+
+.ui-pressable[aria-busy="true"] {
+  cursor: wait;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ui-hover-muted:hover {
+    background-color: hsl(var(--muted));
+    color: hsl(var(--foreground));
+  }
+
+  .ui-hover-accent:hover {
+    background-color: hsl(var(--accent));
+    color: hsl(var(--accent-foreground));
+  }
+
+  .ui-hover-field:hover {
+    border-color: hsl(var(--foreground) / 0.2);
+    background-color: hsl(var(--background) / 0.92);
+  }
+
+  .ui-hover-underline:hover {
+    text-decoration-line: underline;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .ui-pressable:active:not(:disabled):not([aria-disabled="true"]) {
+    transform: scale(var(--scale-small));
+  }
+}
+
+@media (pointer: coarse) {
+  .ui-hit-target,
+  .ui-field {
+    min-width: 44px;
+    min-height: 44px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ui-pressable,
+  .ui-field {
+    transition: none !important;
+  }
+
+  .ui-pressable {
+    transform: none !important;
+  }
+}
+
+@media (forced-colors: active) {
+  .ui-pressable:focus-visible,
+  .ui-field:focus-visible {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
+}

--- a/Frontend/client/src/main.tsx
+++ b/Frontend/client/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import "@fontsource/inter/400.css";
 import "@carrot-kpi/switzer-font/latin-400.css";
 import "./index.css";
+import "./interface-polish.css";
 import { startFrontendLongTaskObserver } from "./lib/frontend-performance";
 import { initializeLocaleCatalog, LocaleProvider } from "./i18n";
 import { AppErrorBoundary } from "./components/AppErrorBoundary";


### PR DESCRIPTION
## Summary

- applies the Interfaces.dev quality checklist to shared UI primitives without redesigning Scriber’s established visual language
- standardizes visible focus, explicit invalid states, 40 px desktop targets, 44 px coarse-pointer targets, reduced-motion behavior, and pointer-gated hover feedback
- makes dynamic numbers stable, long titles and descriptions wrap safely, and page-intro actions occupy a dedicated responsive grid column
- removes interactive hover elevation from passive badges and exposes copied/loading/title state more clearly on compact action controls
- adds focused regression coverage for the shared interaction and typography contracts

## Design intent

The change is deliberately system-level and conservative: dark/light themes, the neumorphic surfaces, the 1320 px page shell, and page-specific motion remain intact. The new `interface-polish.css` layer is loaded after the existing design system and only activates through shared semantic utility classes or low-risk typography selectors.

## Automated validation

- [x] `npm run check`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`
- [x] focused Python gates
- [x] repository-wide Ruff
- [x] complete Python suite and extended mypy
- [x] real-browser File upload smoke test
- [x] Rust formatting, Clippy, and tests
- [x] GitHub Actions syntax

## Manual review checklist

- [ ] keyboard pass: buttons, toggles, inputs, and textareas retain a clearly visible focus indicator
- [ ] pointer pass: hover feedback appears for fine pointers without becoming sticky on coarse pointers
- [ ] reduced-motion pass: press and field transitions are disabled
- [ ] responsive pass: long page titles do not collide with page actions
- [ ] theme pass: field hover, invalid, and focus states remain legible in light and dark themes

## Scope

12 frontend files, 2 focused commits. No backend, persistence, localization catalog, or Tauri API changes.