### PR TITLE
fix(frontend): bind session tokens to backend transport

### DIFF
--- a/Frontend/client/src/lib/backend-url.test.ts
+++ b/Frontend/client/src/lib/backend-url.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { appendBackendSessionToken } from "@/lib/backend-url";
+
+function tokenFor(candidate: string, backend: string): string | null {
+  const result = appendBackendSessionToken(candidate, backend, "secret", "http://fallback.invalid");
+  return new URL(result).searchParams.get("scriberToken");
+}
+
+test("normalizes default ports for matching HTTP and WebSocket transports", () => {
+  assert.equal(tokenFor("http://scriber.local:80/api/health", "http://scriber.local"), "secret");
+  assert.equal(tokenFor("ws://scriber.local/ws", "http://scriber.local:80"), "secret");
+  assert.equal(tokenFor("https://scriber.local:443/api/health", "https://scriber.local"), "secret");
+  assert.equal(tokenFor("wss://scriber.local/ws", "https://scriber.local:443"), "secret");
+});
+
+test("does not attach a token across secure and insecure transport families", () => {
+  assert.equal(tokenFor("http://scriber.local:443/api/health", "https://scriber.local"), null);
+  assert.equal(tokenFor("https://scriber.local:80/api/health", "http://scriber.local"), null);
+  assert.equal(tokenFor("ws://scriber.local:443/ws", "https://scriber.local"), null);
+  assert.equal(tokenFor("wss://scriber.local:80/ws", "http://scriber.local"), null);
+});
+
+test("limits the token to the configured backend host, port, and authenticated paths", () => {
+  assert.equal(tokenFor("http://other.local/api/health", "http://scriber.local"), null);
+  assert.equal(tokenFor("http://scriber.local:8766/api/health", "http://scriber.local:8765"), null);
+  assert.equal(tokenFor("http://scriber.local/public", "http://scriber.local"), null);
+});
+
+test("preserves existing query parameters and replaces a stale token", () => {
+  const result = appendBackendSessionToken(
+    "http://scriber.local/api/health?mode=full&scriberToken=stale",
+    "http://scriber.local:80",
+    "fresh",
+    "http://fallback.invalid",
+  );
+  const parsed = new URL(result);
+  assert.equal(parsed.searchParams.get("mode"), "full");
+  assert.equal(parsed.searchParams.get("scriberToken"), "fresh");
+});

--- a/Frontend/client/src/lib/backend-url.test.ts
+++ b/Frontend/client/src/lib/backend-url.test.ts
@@ -1,41 +1,33 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { appendBackendSessionToken } from "@/lib/backend-url";
+import { targetsSameBackend } from "@/lib/backend-url";
 
-function tokenFor(candidate: string, backend: string): string | null {
-  const result = appendBackendSessionToken(candidate, backend, "secret", "http://fallback.invalid");
-  return new URL(result).searchParams.get("scriberToken");
+function matches(candidate: string, backend: string): boolean {
+  return targetsSameBackend(new URL(candidate), new URL(backend));
 }
 
 test("normalizes default ports for matching HTTP and WebSocket transports", () => {
-  assert.equal(tokenFor("http://scriber.local:80/api/health", "http://scriber.local"), "secret");
-  assert.equal(tokenFor("ws://scriber.local/ws", "http://scriber.local:80"), "secret");
-  assert.equal(tokenFor("https://scriber.local:443/api/health", "https://scriber.local"), "secret");
-  assert.equal(tokenFor("wss://scriber.local/ws", "https://scriber.local:443"), "secret");
+  assert.equal(matches("http://scriber.local:80/api/health", "http://scriber.local"), true);
+  assert.equal(matches("ws://scriber.local/ws", "http://scriber.local:80"), true);
+  assert.equal(matches("https://scriber.local:443/api/health", "https://scriber.local"), true);
+  assert.equal(matches("wss://scriber.local/ws", "https://scriber.local:443"), true);
 });
 
-test("does not attach a token across secure and insecure transport families", () => {
-  assert.equal(tokenFor("http://scriber.local:443/api/health", "https://scriber.local"), null);
-  assert.equal(tokenFor("https://scriber.local:80/api/health", "http://scriber.local"), null);
-  assert.equal(tokenFor("ws://scriber.local:443/ws", "https://scriber.local"), null);
-  assert.equal(tokenFor("wss://scriber.local:80/ws", "http://scriber.local"), null);
+test("rejects matches across secure and insecure transport families", () => {
+  assert.equal(matches("http://scriber.local:443/api/health", "https://scriber.local"), false);
+  assert.equal(matches("https://scriber.local:80/api/health", "http://scriber.local"), false);
+  assert.equal(matches("ws://scriber.local:443/ws", "https://scriber.local"), false);
+  assert.equal(matches("wss://scriber.local:80/ws", "http://scriber.local"), false);
 });
 
-test("limits the token to the configured backend host, port, and authenticated paths", () => {
-  assert.equal(tokenFor("http://other.local/api/health", "http://scriber.local"), null);
-  assert.equal(tokenFor("http://scriber.local:8766/api/health", "http://scriber.local:8765"), null);
-  assert.equal(tokenFor("http://scriber.local/public", "http://scriber.local"), null);
+test("requires the configured backend hostname and effective port", () => {
+  assert.equal(matches("http://other.local/api/health", "http://scriber.local"), false);
+  assert.equal(matches("http://scriber.local:8766/api/health", "http://scriber.local:8765"), false);
+  assert.equal(matches("http://scriber.local:8765/api/health", "http://scriber.local:8765"), true);
 });
 
-test("preserves existing query parameters and replaces a stale token", () => {
-  const result = appendBackendSessionToken(
-    "http://scriber.local/api/health?mode=full&scriberToken=stale",
-    "http://scriber.local:80",
-    "fresh",
-    "http://fallback.invalid",
-  );
-  const parsed = new URL(result);
-  assert.equal(parsed.searchParams.get("mode"), "full");
-  assert.equal(parsed.searchParams.get("scriberToken"), "fresh");
+test("rejects unsupported transport protocols", () => {
+  assert.equal(matches("ftp://scriber.local/api/health", "http://scriber.local"), false);
+  assert.equal(matches("http://scriber.local/api/health", "ftp://scriber.local"), false);
 });

--- a/Frontend/client/src/lib/backend-url.ts
+++ b/Frontend/client/src/lib/backend-url.ts
@@ -14,7 +14,7 @@ function effectivePort(url: URL, transport: BackendTransport): string {
   return url.port || (transport === "secure" ? "443" : "80");
 }
 
-function targetsSameBackend(candidate: URL, backend: URL): boolean {
+export function targetsSameBackend(candidate: URL, backend: URL): boolean {
   const candidateTransport = backendTransport(candidate.protocol);
   const configuredTransport = backendTransport(backend.protocol);
   if (candidateTransport === null || configuredTransport === null) {
@@ -25,28 +25,4 @@ function targetsSameBackend(candidate: URL, backend: URL): boolean {
     candidate.hostname === backend.hostname &&
     effectivePort(candidate, candidateTransport) === effectivePort(backend, configuredTransport)
   );
-}
-
-export function appendBackendSessionToken(
-  url: string,
-  backendBaseUrl: string,
-  sessionToken: string,
-  fallbackOrigin: string,
-): string {
-  if (!sessionToken) {
-    return url;
-  }
-
-  try {
-    const parsed = new URL(url, backendBaseUrl || fallbackOrigin);
-    const backend = new URL(backendBaseUrl || fallbackOrigin);
-    const authenticatedPath = parsed.pathname === "/ws" || parsed.pathname.startsWith("/api/");
-    if (authenticatedPath && targetsSameBackend(parsed, backend)) {
-      parsed.searchParams.set("scriberToken", sessionToken);
-      return parsed.toString();
-    }
-  } catch {
-    // Preserve the caller's original URL when parsing fails.
-  }
-  return url;
 }

--- a/Frontend/client/src/lib/backend-url.ts
+++ b/Frontend/client/src/lib/backend-url.ts
@@ -1,0 +1,52 @@
+type BackendTransport = "secure" | "insecure";
+
+function backendTransport(protocol: string): BackendTransport | null {
+  if (protocol === "https:" || protocol === "wss:") {
+    return "secure";
+  }
+  if (protocol === "http:" || protocol === "ws:") {
+    return "insecure";
+  }
+  return null;
+}
+
+function effectivePort(url: URL, transport: BackendTransport): string {
+  return url.port || (transport === "secure" ? "443" : "80");
+}
+
+function targetsSameBackend(candidate: URL, backend: URL): boolean {
+  const candidateTransport = backendTransport(candidate.protocol);
+  const configuredTransport = backendTransport(backend.protocol);
+  if (candidateTransport === null || configuredTransport === null) {
+    return false;
+  }
+  return (
+    candidateTransport === configuredTransport &&
+    candidate.hostname === backend.hostname &&
+    effectivePort(candidate, candidateTransport) === effectivePort(backend, configuredTransport)
+  );
+}
+
+export function appendBackendSessionToken(
+  url: string,
+  backendBaseUrl: string,
+  sessionToken: string,
+  fallbackOrigin: string,
+): string {
+  if (!sessionToken) {
+    return url;
+  }
+
+  try {
+    const parsed = new URL(url, backendBaseUrl || fallbackOrigin);
+    const backend = new URL(backendBaseUrl || fallbackOrigin);
+    const authenticatedPath = parsed.pathname === "/ws" || parsed.pathname.startsWith("/api/");
+    if (authenticatedPath && targetsSameBackend(parsed, backend)) {
+      parsed.searchParams.set("scriberToken", sessionToken);
+      return parsed.toString();
+    }
+  } catch {
+    // Preserve the caller's original URL when parsing fails.
+  }
+  return url;
+}

--- a/Frontend/client/src/lib/backend.ts
+++ b/Frontend/client/src/lib/backend.ts
@@ -4,7 +4,7 @@ import {
   type FrontendReadyRequest,
   type FrontendReadyResponse,
 } from "@/lib/api-types";
-import { appendBackendSessionToken } from "@/lib/backend-url";
+import { targetsSameBackend } from "@/lib/backend-url";
 import { responseDetailMessage } from "@/lib/request-errors";
 import { fetchWithTimeout, withPromiseTimeout } from "@/lib/fetch-with-timeout";
 import { translateNow } from "@/i18n";
@@ -107,7 +107,18 @@ function appendSessionToken(url: string): string {
   if (!backendSessionToken || typeof window === "undefined") {
     return url;
   }
-  return appendBackendSessionToken(url, backendBaseUrl, backendSessionToken, window.location.origin);
+  try {
+    const parsed = new URL(url, backendBaseUrl || window.location.origin);
+    const backend = new URL(backendBaseUrl || window.location.origin);
+    const targetsBackend = targetsSameBackend(parsed, backend);
+    if (targetsBackend && (parsed.pathname === "/ws" || parsed.pathname.startsWith("/api/"))) {
+      parsed.searchParams.set("scriberToken", backendSessionToken);
+      return parsed.toString();
+    }
+  } catch {
+    return url;
+  }
+  return url;
 }
 
 export function loadBackendBaseUrlFromTauri(): Promise<string> {

--- a/Frontend/client/src/lib/backend.ts
+++ b/Frontend/client/src/lib/backend.ts
@@ -4,6 +4,7 @@ import {
   type FrontendReadyRequest,
   type FrontendReadyResponse,
 } from "@/lib/api-types";
+import { appendBackendSessionToken } from "@/lib/backend-url";
 import { responseDetailMessage } from "@/lib/request-errors";
 import { fetchWithTimeout, withPromiseTimeout } from "@/lib/fetch-with-timeout";
 import { translateNow } from "@/i18n";
@@ -106,21 +107,7 @@ function appendSessionToken(url: string): string {
   if (!backendSessionToken || typeof window === "undefined") {
     return url;
   }
-  try {
-    const parsed = new URL(url, backendBaseUrl || window.location.origin);
-    const backend = new URL(backendBaseUrl || window.location.origin);
-    // URL.port is "" for default ports, so normalize before comparing
-    // (e.g. "http://host" must match "http://host:80").
-    const effectivePort = (u: URL) => u.port || (u.protocol === "https:" || u.protocol === "wss:" ? "443" : "80");
-    const targetsBackend = parsed.hostname === backend.hostname && effectivePort(parsed) === effectivePort(backend);
-    if (targetsBackend && (parsed.pathname === "/ws" || parsed.pathname.startsWith("/api/"))) {
-      parsed.searchParams.set("scriberToken", backendSessionToken);
-      return parsed.toString();
-    }
-  } catch {
-    return url;
-  }
-  return url;
+  return appendBackendSessionToken(url, backendBaseUrl, backendSessionToken, window.location.origin);
 }
 
 export function loadBackendBaseUrlFromTauri(): Promise<string> {


### PR DESCRIPTION
## Summary

- preserves the existing default-port normalization from the Claude Code review
- requires the candidate URL to use the same transport family as the configured backend: `http`/`ws` or `https`/`wss`
- prevents a session token from being attached to a same-host, same-port URL that crosses between secure and insecure transports
- extracts backend endpoint matching into a small pure helper while keeping authenticated-path checks and token mutation at the existing backend authentication boundary
- adds focused regression coverage for default ports, transport families, hostnames, ports, and unsupported protocols

## Review of the linked suggestions

The linked Claude session maps to commit `4fed456e3e30a51af644f3fdbbb3cd677a3f1fe2`, which is already an ancestor of `main`.

- **Default-port normalization:** approved and retained. The original implementation compared host and effective port but did not distinguish secure from insecure transports. This PR closes that remaining token-scoping gap.
- **Shared response-detail parser:** approved and already present on `main`; no duplicate change.
- **Shared process helpers:** approved and already present on `main`; no duplicate change.
- **PySide6/tkinter overlay fallback:** historically reasonable, but obsolete because the current runtime uses the native Tauri overlay and the legacy module has been removed.
- **Collapsing the lazy pipeline loader:** not reapplied. Current `main` has import locking, off-event-loop construction, deferred cache cleanup, and explicit cancellation ownership that the old simplification would weaken.

## Security boundary

Session-token mutation remains limited to authenticated backend paths (`/api/*` and `/ws`). Endpoint matching now fails closed unless hostname, effective port, and transport security family all agree. HTTP and WebSocket variants are paired only within the same family (`http` with `ws`, `https` with `wss`); unsupported protocols are rejected.

## Validation

- [x] focused TypeScript/Node regression tests for default ports, HTTP/WebSocket pairing, secure/insecure rejection, host/port scoping, and unsupported protocols
- [x] frontend typecheck, lint, tests, and production build
- [x] focused Python hybrid gates
- [x] repository-wide Ruff lint and formatting checks
- [x] complete Python suite, real-browser File-upload smoke, and extended mypy tranche
- [x] Rust formatting, Clippy, and tests
- [x] GitHub Actions workflow syntax

`Hybrid PR Checks` run 328 completed successfully for head `ff297d6ddb1e4c5998cf303d56657f1b6b5a6798`.
