### PR TITLE
fix: consume repeated YouTube browser handoffs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,11 @@ Frontend and shell:
   while Debug Console, transcript detail, and not-found surfaces remain lazy.
 - `Frontend/client/src/pages/`: Live Mic, Meetings, YouTube, File, Settings,
   Debug Console, Transcript Detail.
+- `Frontend/client/src/hooks/use-browser-youtube-import.ts` owns one-shot
+  browser handoff consumption. It must subscribe to search-string changes so a
+  second `scriber://` request is consumed even when the running app is already
+  on `/youtube`, and it must retain a new request while an earlier start is in
+  flight.
 - Meeting review keeps its timeline math and deterministic search/filter rules
   in `Frontend/client/src/lib/meeting-review-timeline.ts`; do not duplicate them
   in row rendering or transport code. `MeetingReviewToolbar` owns the visible

--- a/Frontend/client/src/hooks/use-browser-youtube-import.test.tsx
+++ b/Frontend/client/src/hooks/use-browser-youtube-import.test.tsx
@@ -1,0 +1,62 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { YouTubeSearchItem } from "@/lib/api-types";
+import { useBrowserYoutubeImport } from "./use-browser-youtube-import";
+
+interface HarnessProps {
+  busy?: boolean;
+  onImport: (item: YouTubeSearchItem) => void;
+}
+
+function Harness({ busy = false, onImport }: HarnessProps) {
+  useBrowserYoutubeImport({ busy, onImport });
+  return null;
+}
+
+const requestSearch =
+  "?browserVideo=0wEjbSYNUM8&browserRequest=0123456789abcdef0123456789abcdef" +
+  "&browserTitle=Browser%20handoff&browserChannel=Scriber";
+
+describe("useBrowserYoutubeImport", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/youtube");
+  });
+
+  it("consumes a query-only handoff while the YouTube route is already open", async () => {
+    const onImport = vi.fn();
+    render(<Harness onImport={onImport} />);
+
+    act(() => {
+      window.history.pushState(null, "", `/youtube${requestSearch}`);
+    });
+
+    await waitFor(() => expect(onImport).toHaveBeenCalledTimes(1));
+    expect(onImport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        videoId: "0wEjbSYNUM8",
+        url: "https://www.youtube.com/watch?v=0wEjbSYNUM8",
+        title: "Browser handoff",
+        channelTitle: "Scriber",
+      }),
+    );
+    expect(window.location.pathname).toBe("/youtube");
+    expect(window.location.search).toBe("");
+  });
+
+  it("keeps a pending handoff until the current start request settles", async () => {
+    const onImport = vi.fn();
+    const view = render(<Harness busy onImport={onImport} />);
+
+    act(() => {
+      window.history.pushState(null, "", `/youtube${requestSearch}`);
+    });
+    expect(onImport).not.toHaveBeenCalled();
+    expect(window.location.search).toBe(requestSearch);
+
+    view.rerender(<Harness onImport={onImport} />);
+
+    await waitFor(() => expect(onImport).toHaveBeenCalledTimes(1));
+    expect(window.location.search).toBe("");
+  });
+});

--- a/Frontend/client/src/hooks/use-browser-youtube-import.ts
+++ b/Frontend/client/src/hooks/use-browser-youtube-import.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from "react";
+import { useSearch } from "wouter";
+
+import type { YouTubeSearchItem } from "@/lib/api-types";
+import { parseBrowserYoutubeImport, stripBrowserYoutubeImportParams } from "@/lib/browser-youtube-import";
+
+interface BrowserYoutubeImportOptions {
+  busy: boolean;
+  onImport: (item: YouTubeSearchItem) => void | Promise<void>;
+}
+
+export function useBrowserYoutubeImport({ busy, onImport }: BrowserYoutubeImportOptions): void {
+  const search = useSearch();
+  const handledRequestRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || busy) {
+      return;
+    }
+    const imported = parseBrowserYoutubeImport(search);
+    if (!imported || imported.requestId === handledRequestRef.current) {
+      return;
+    }
+
+    handledRequestRef.current = imported.requestId;
+    const nextSearch = stripBrowserYoutubeImportParams(search);
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${window.location.pathname}${nextSearch ? `?${nextSearch}` : ""}${window.location.hash}`,
+    );
+    void onImport(imported.item);
+  }, [busy, onImport, search]);
+}

--- a/Frontend/client/src/pages/Youtube.tsx
+++ b/Frontend/client/src/pages/Youtube.tsx
@@ -37,7 +37,8 @@ import type {
 } from "@/lib/api-types";
 import { useI18n } from "@/i18n";
 import { useTranscriptHistoryPanelState } from "@/hooks/use-transcript-history-panel-state";
-import { parseBrowserYoutubeImport, stripBrowserYoutubeImportParams } from "@/lib/browser-youtube-import";
+import { useBrowserYoutubeImport } from "@/hooks/use-browser-youtube-import";
+import { parseBrowserYoutubeImport } from "@/lib/browser-youtube-import";
 
 type SortOption = "date" | "likes" | "views";
 
@@ -426,7 +427,6 @@ export default function Youtube() {
   const deletingRef = useRef<string | null>(null);
   const copyingRef = useRef<string | null>(null);
   const retryingTranscriptRef = useRef<string | null>(null);
-  const handledBrowserRequestRef = useRef<string | null>(null);
   const copyResetTimerRef = useRef<number | null>(null);
   const [sortBy, setSortBy] = useUrlQueryState<SortOption>("sort", "date", {
     parse: (raw) => (raw === "likes" || raw === "views" ? raw : "date"),
@@ -620,23 +620,7 @@ export default function Youtube() {
     [debouncedHistorySearch, location, queryClient, setLocation, t, toast, transcriptsQueryKey],
   );
 
-  useEffect(() => {
-    if (typeof window === "undefined" || startRequestInFlightRef.current) {
-      return;
-    }
-    const imported = parseBrowserYoutubeImport(window.location.search);
-    if (!imported || imported.requestId === handledBrowserRequestRef.current) {
-      return;
-    }
-    handledBrowserRequestRef.current = imported.requestId;
-    const nextSearch = stripBrowserYoutubeImportParams(window.location.search);
-    window.history.replaceState(
-      window.history.state,
-      "",
-      `${window.location.pathname}${nextSearch ? `?${nextSearch}` : ""}${window.location.hash}`,
-    );
-    void startTranscription(imported.item);
-  }, [location, startTranscription, startingVideoId]);
+  useBrowserYoutubeImport({ busy: startingVideoId !== null, onImport: startTranscription });
 
   const deleteTranscript = useCallback(
     async (e: React.MouseEvent, id: string) => {

--- a/docs/TESTING_AND_RELEASE.md
+++ b/docs/TESTING_AND_RELEASE.md
@@ -161,7 +161,9 @@ npm run test:lib
 The extension gate pins Manifest V3, the narrow YouTube-only content-script
 matches, exact video-route parsing, and the credential-free versioned
 `scriber://` payload. The frontend gate pins one-shot consumption into the
-existing authenticated YouTube job request.
+existing authenticated YouTube job request, including a query-only handoff
+while the already-running app is still on `/youtube` and deferred consumption
+while an earlier start request is in flight.
 
 Use the exact Node.js 26.5.0 version from `.node-version`; CI and release builds
 consume that pin, while `Frontend/package.json` declares the supported


### PR DESCRIPTION
## Summary
- subscribe browser imports to search-string changes instead of pathname-only navigation
- preserve a pending handoff while an earlier YouTube start request is in flight
- add component regressions for an already-open /youtube route and deferred consumption

## Installed failure evidence
- v0.5.91 accepted the redacted shell handoff and opened /youtube, but created no new YouTube job
- the exact v0.5.91 release was restored to draft without moving its immutable tag

## Validation
- npm run check
- npm run lint
- npm test (98 library + 73 component tests)
- npm run build
- focused new component tests: 2 passed
- tests/test_frontend_type_gates.py: 104 passed
- Chrome extension contract: 3 passed