### PR TITLE
fix: canceled STT uploads, note autosave races, exports, and search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,10 @@ Frontend and shell:
   note hand-off owner. Playback may follow the active virtual row only while
   Follow is enabled; a manual review scroll must turn Follow off rather than
   fight the user. Keep live Latest-text following as a separate behavior.
+- Meeting note teardown saves compare the current draft with the newest
+  effective write generation. Matching older saved or in-flight text must not
+  skip a newer write needed to preserve a user revert; discard superseded
+  queued drafts before deduplicating the teardown save.
 - `Frontend/client/src/contexts/WebSocketContext.tsx`: shared WebSocket.
 - `Frontend/client/src/lib/backend.ts`: backend URL and Tauri token bridge.
 - `Frontend/client/src/lib/api-types.ts`: shared REST-facing TS types.
@@ -845,13 +849,17 @@ Packaging and scripts:
 - Meeting and canonical transcript FTS5 projections use base-table `rowid` as
   their FTS `rowid`. Keep schema-versioned atomic rebuilds, rowid-based trigger
   deletes/parity checks, Meeting-scoped MATCH expressions, and the explicit
-  single-snapshot transaction in `MeetingStore.detail`.
+  single-snapshot transaction in `MeetingStore.detail`. Punctuation-only
+  transcript searches use literal substrings, never SQL wildcard semantics.
 - Durable File/YouTube job claims and terminal transitions are SQL CAS updates.
   Preserve idempotent `queued/running/completed -> completed` reconciliation,
   but never allow a late completion to overwrite `canceled` or `failed`.
 - Meeting exports must use `src/meeting_export.py` as the shared template
-  boundary. Email headers must remain single-line and participant addresses
-  validated/deduplicated; body-only drafts must not claim an attachment exists.
+  boundary. Their duration uses the retained playback mix's duration plus
+  Meeting-clock origin, including trailing silence; segment end times are the
+  fallback when no mix duration is available. Email headers must remain
+  single-line and participant addresses validated/deduplicated; body-only drafts
+  must not claim an attachment exists.
   Saved `.eml` drafts use SMTP CRLF line endings, an ASCII-safe
   quoted-printable UTF-8 body, plus `X-Unsent: 1`, and the
   selected PDF, DOCX, or Markdown attachment must remain a real MIME part when
@@ -1187,6 +1195,10 @@ Packaging and scripts:
   and must consume `STTUpdateSettingsFrame.delta`; do not restore legacy
   `frame.settings` dictionaries or constructors that leave Pipecat settings as
   `NOT_GIVEN`.
+- Buffered STT cancellation discards PCM and releases adopted WAV artifacts
+  without encoding, uploading, or emitting final text. Recording gates discard
+  active boundaries on `CancelFrame`, including later cleanup flushes;
+  `EndFrame` and `StopFrame` retain their normal finalization behavior.
 - Do not add Pipecat's `local-smart-turn` extra to the standard sidecar: in
   Pipecat 1.5 it pulls Torch, Torchaudio, and Transformers. SmartTurn remains
   optional; import `LocalSmartTurnAnalyzerV3` directly and do not couple it to

--- a/Frontend/client/src/components/meeting/MeetingNotesEditor.test.tsx
+++ b/Frontend/client/src/components/meeting/MeetingNotesEditor.test.tsx
@@ -212,6 +212,83 @@ describe("MeetingNotesEditor autosave", () => {
     expect(screen.getByLabelText("Notes autosave and AI regeneration never overwrites them.")).toBeInTheDocument();
   });
 
+  it("saves a reverted draft on pagehide before an older autosave can overwrite it", async () => {
+    const olderSave = deferred<MeetingNote>();
+    const revertedSave = deferred<MeetingNote>();
+    const saveNote = vi.fn<SaveMeetingNote>(() => olderSave.promise);
+    const teardownSave = vi.fn<SaveMeetingNote>(() => revertedSave.promise);
+    const onSaved = vi.fn();
+
+    render(
+      <NotesHarness
+        initialBody="original"
+        meetingId="meeting-reverted"
+        onSaved={onSaved}
+        saveNote={saveNote}
+        saveNoteOnTeardown={teardownSave}
+      />,
+    );
+    const editor = screen.getByRole("textbox", { name: "Live notes" });
+    fireEvent.change(editor, { target: { value: "temporary edit" } });
+    await advanceAutosave();
+    fireEvent.change(editor, { target: { value: "original" } });
+
+    act(() => window.dispatchEvent(new Event("pagehide")));
+    expect(teardownSave).toHaveBeenCalledWith("meeting-reverted", "original", {
+      writerId: TEST_WRITER_ID,
+      generation: 2,
+    });
+    act(() => window.dispatchEvent(new Event("pagehide")));
+    expect(teardownSave).toHaveBeenCalledTimes(1);
+
+    await resolveSave(revertedSave, note("original", { generation: 2, applied: true }));
+    act(() => window.dispatchEvent(new Event("pagehide")));
+    expect(teardownSave).toHaveBeenCalledTimes(1);
+    await resolveSave(olderSave, note("original", { generation: 2, applied: false }));
+    expect(saveNote).toHaveBeenCalledTimes(1);
+    expect(onSaved).toHaveBeenLastCalledWith(expect.objectContaining({ body: "original" }), "meeting-reverted");
+  });
+
+  it.each([false, true])(
+    "persists a draft matching an older request after a newer pagehide save (completed: %s)",
+    async (newerSaveCompleted) => {
+      const meetingId = `meeting-superseded-${newerSaveCompleted}`;
+      const olderSave = deferred<MeetingNote>();
+      const newerSave = deferred<MeetingNote>();
+      const latestSave = deferred<MeetingNote>();
+      const saveNote = vi.fn<SaveMeetingNote>(() => olderSave.promise);
+      const teardownSave = vi
+        .fn<SaveMeetingNote>()
+        .mockImplementationOnce(() => newerSave.promise)
+        .mockImplementationOnce(() => latestSave.promise);
+
+      render(<NotesHarness meetingId={meetingId} saveNote={saveNote} saveNoteOnTeardown={teardownSave} />);
+      const editor = screen.getByRole("textbox", { name: "Live notes" });
+      fireEvent.change(editor, { target: { value: "A" } });
+      await advanceAutosave();
+      fireEvent.change(editor, { target: { value: "B" } });
+      act(() => window.dispatchEvent(new Event("pagehide")));
+      if (newerSaveCompleted) {
+        await resolveSave(newerSave, note("B", { generation: 2, applied: true }));
+      }
+
+      fireEvent.change(editor, { target: { value: "A" } });
+      act(() => window.dispatchEvent(new Event("pagehide")));
+      expect(teardownSave).toHaveBeenLastCalledWith(meetingId, "A", {
+        writerId: TEST_WRITER_ID,
+        generation: 3,
+      });
+      expect(teardownSave).toHaveBeenCalledTimes(2);
+
+      await resolveSave(latestSave, note("A", { generation: 3, applied: true }));
+      if (!newerSaveCompleted) {
+        await resolveSave(newerSave, note("A", { generation: 3, applied: false }));
+      }
+      await resolveSave(olderSave, note("A", { generation: 3, applied: false }));
+      expect(saveNote).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it("raises its generation floor and retries after a stale response", async () => {
     const retry = deferred<MeetingNote>();
     const saveNote = vi

--- a/Frontend/client/src/components/meeting/useMeetingNotesAutosave.ts
+++ b/Frontend/client/src/components/meeting/useMeetingNotesAutosave.ts
@@ -356,11 +356,22 @@ class MeetingNotesSaveQueue {
 
   flushForTeardown = (): void => {
     const body = normalizeBody(this.draftBody);
-    if (body === this.savedBody || body === this.inFlightWrite?.body || body === this.teardownWrite?.body) {
+    // Compare against the newest effective write. Matching the last saved body
+    // or a superseded request does not protect a revert from a later write.
+    let latestBody = this.savedBody;
+    let latestGeneration = this.lastAppliedWrite;
+    for (const pending of [this.inFlightWrite, this.teardownWrite]) {
+      if (pending && pending.generation > latestGeneration) {
+        latestBody = pending.body;
+        latestGeneration = pending.generation;
+      }
+    }
+    this.queuedBody = null;
+    if (body === latestBody) {
+      this.emit();
       return;
     }
 
-    this.queuedBody = null;
     this.error = null;
     const generation = this.nextGeneration();
     const pending = { body, generation };

--- a/src/assemblyai_async_stt.py
+++ b/src/assemblyai_async_stt.py
@@ -439,7 +439,7 @@ class AssemblyAIUniversal35ProAsyncProcessor(FrameProcessor):
                     self._reset_buffer()
                     await self.push_frame(frame, direction)
                     return
-                if self._buffer_size:
+                if self._buffer_size and not isinstance(frame, CancelFrame):
                     _report_progress(self._on_progress, "Transcribing...")
                     wav_source = await asyncio.to_thread(
                         pcm_stream_to_wav,

--- a/src/cloud_async_stt.py
+++ b/src/cloud_async_stt.py
@@ -1164,7 +1164,8 @@ class _BufferedAsyncProcessor(FrameProcessor):
                     self._reset_buffer()
                     await self.push_frame(frame, direction)
                     return
-                if self._buffer_size:
+                # Cancellation releases both audio owners without starting an upload.
+                if self._buffer_size and not isinstance(frame, CancelFrame):
                     _report_progress(self._on_progress, "Transcribing...")
                     if artifact is not None and artifact.matches_pcm(
                         sample_rate=self._sample_rate,

--- a/src/database.py
+++ b/src/database.py
@@ -779,24 +779,27 @@ def search_transcript_metadata(
                 total = conn.execute(total_sql, [fts_q, *params]).fetchone()["c"]
                 rows = conn.execute(rows_sql, [fts_q, *params, limit, offset]).fetchall() if limit > 0 else []
             else:
-                like = f"%{q.lower()}%"
+                # Punctuation-only searches are literal substrings. LIKE would
+                # interpret a searched percent sign as an SQL wildcard.
+                literal = q.lower()
                 total_sql = (
                     "SELECT COUNT(*) AS c FROM transcripts t "
-                    "WHERE (LOWER(t.title) LIKE ? OR LOWER(t.content) LIKE ? OR "
-                    "LOWER(scriber_summary_text(t.summary, t.summary_format)) LIKE ? OR LOWER(t.channel) LIKE ?) "
-                    + ("AND t.type = ?" if transcript_type else "")
+                    "WHERE (instr(LOWER(t.title), ?) > 0 OR instr(LOWER(t.content), ?) > 0 OR "
+                    "instr(LOWER(scriber_summary_text(t.summary, t.summary_format)), ?) > 0 OR "
+                    "instr(LOWER(t.channel), ?) > 0) " + ("AND t.type = ?" if transcript_type else "")
                 )
                 rows_sql = (
                     "SELECT t.id, t.title, t.date, t.duration, t.status, t.type, t.language, t.step, "
                     "t.source_url, t.channel, t.thumbnail_url, t.created_at, t.updated_at, t.preview, "
                     "t.summary_format, t.summary_status, t.summary_error, t.summary_updated_at "
                     "FROM transcripts t "
-                    "WHERE (LOWER(t.title) LIKE ? OR LOWER(t.content) LIKE ? OR "
-                    "LOWER(scriber_summary_text(t.summary, t.summary_format)) LIKE ? OR LOWER(t.channel) LIKE ?) "
+                    "WHERE (instr(LOWER(t.title), ?) > 0 OR instr(LOWER(t.content), ?) > 0 OR "
+                    "instr(LOWER(scriber_summary_text(t.summary, t.summary_format)), ?) > 0 OR "
+                    "instr(LOWER(t.channel), ?) > 0) "
                     + ("AND t.type = ? " if transcript_type else "")
                     + "ORDER BY t.created_at DESC, t.id DESC LIMIT ? OFFSET ?"
                 )
-                args = [like, like, like, like]
+                args = [literal, literal, literal, literal]
                 if transcript_type:
                     args.append(transcript_type)
                 total = conn.execute(total_sql, args).fetchone()["c"]

--- a/src/meeting_export.py
+++ b/src/meeting_export.py
@@ -252,6 +252,13 @@ def _single_line(value: Any, *, limit: int) -> str:
 
 
 def meeting_duration_ms(detail: dict[str, Any]) -> int:
+    # Speech timestamps omit trailing silence. Use the retained playback mix's
+    # full Meeting-clock extent, matching the review player's timeline.
+    mix = next((item for item in detail.get("audioAssets", []) if item.get("kind") == "playback_mix"), None)
+    if mix is not None and mix.get("durationMs") is not None:
+        tracks = mix.get("trackManifest") or []
+        track = next((item for item in tracks if item.get("source") == "mixed"), tracks[0] if tracks else {})
+        return max(0, int(track.get("timelineOriginMs") or 0)) + max(0, int(mix["durationMs"]))
     return max((int(item.get("endMs", 0)) for item in detail.get("segments", [])), default=0)
 
 

--- a/src/mistral_stt.py
+++ b/src/mistral_stt.py
@@ -397,7 +397,7 @@ class MistralAsyncProcessor(FrameProcessor):
                     self._reset_buffer()
                     await self.push_frame(frame, direction)
                     return
-                if self._buffer_size:
+                if self._buffer_size and not isinstance(frame, CancelFrame):
                     self._report_progress("Transcribing...")
                     wav_source = await asyncio.to_thread(
                         pcm_stream_to_wav,

--- a/src/modulate_stt.py
+++ b/src/modulate_stt.py
@@ -273,7 +273,7 @@ class ModulateAsyncProcessor(FrameProcessor):
                     logger.info("Modulate async: skipping terminal transcription for silent recording")
                 elif self._oversized:
                     logger.warning("Modulate async recording exceeded the provider upload limit")
-                elif self._buffer_size:
+                elif self._buffer_size and not isinstance(frame, CancelFrame):
                     _report_progress(self._on_progress, "Transcribing...")
                     wav_source = await asyncio.to_thread(
                         pcm_stream_to_wav,

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -819,7 +819,9 @@ class SonioxAsyncProcessor(FrameProcessor):
             await self.push_frame(frame, direction)
         elif isinstance(frame, (EndFrame, StopFrame, CancelFrame)):
             try:
-                if getattr(self, "_skip_terminal_transcription", False):
+                if isinstance(frame, CancelFrame):
+                    logger.debug("Soniox async: discarding canceled recording")
+                elif getattr(self, "_skip_terminal_transcription", False):
                     logger.info("Soniox async: skipping terminal transcription for silent recording")
                 elif not self._buffer_size:
                     logger.debug("Soniox async: no audio buffered; skipping transcription")
@@ -1723,6 +1725,15 @@ class SegmentedSTTRecordingGate(FrameProcessor):
                 await self.push_frame(VADUserStartedSpeakingFrame(), direction)
             return
 
+        if isinstance(frame, CancelFrame):
+            # A synthetic VAD stop commits buffered audio at the provider.
+            # Abandon the boundary so cancellation and cleanup cannot upload it.
+            self._whole_recording_open = False
+            self._whole_recording_closed = True
+            self._vad_user_speaking = False
+            await self.push_frame(frame, direction)
+            return
+
         if self.vad_segmentation_enabled:
             if isinstance(frame, VADUserStartedSpeakingFrame):
                 self._vad_user_speaking = True
@@ -1736,7 +1747,7 @@ class SegmentedSTTRecordingGate(FrameProcessor):
             # split HTTP upload-based STT providers unless the user opted in.
             return
 
-        if isinstance(frame, (EndFrame, StopFrame, CancelFrame)):
+        if isinstance(frame, (EndFrame, StopFrame)):
             await self.flush_segment(direction=direction)
             await self.push_frame(frame, direction)
             return

--- a/src/smallest_stt.py
+++ b/src/smallest_stt.py
@@ -293,7 +293,7 @@ class SmallestAsyncProcessor(FrameProcessor):
                     self._reset_buffer()
                     await self.push_frame(frame, direction)
                     return
-                if self._buffer_size:
+                if self._buffer_size and not isinstance(frame, CancelFrame):
                     _report_progress(self._on_progress, "Transcribing...")
                     wav_source = await asyncio.to_thread(
                         pcm_stream_to_wav,

--- a/tests/test_buffered_stt_cancellation.py
+++ b/tests/test_buffered_stt_cancellation.py
@@ -1,0 +1,90 @@
+import wave
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from pipecat.frames.frames import CancelFrame, EndFrame, ErrorFrame, InputAudioRawFrame, StopFrame, TranscriptionFrame
+from pipecat.processors.frame_processor import FrameDirection
+
+from src.assemblyai_async_stt import AssemblyAIUniversal35ProAsyncProcessor
+from src.cloud_async_stt import SpeechmaticsAsyncProcessor
+from src.mistral_stt import MistralAsyncProcessor
+from src.modulate_stt import ModulateAsyncProcessor
+from src.pipeline import SonioxAsyncProcessor
+from src.smallest_stt import SmallestAsyncProcessor
+
+
+@pytest.mark.parametrize(
+    "processor_type,options,transcribe_attribute",
+    [
+        (AssemblyAIUniversal35ProAsyncProcessor, {}, "_transcribe_wav"),
+        (SpeechmaticsAsyncProcessor, {"language": "de"}, "_transcribe_wav"),
+        (MistralAsyncProcessor, {"model": "voxtral-mini-2602"}, "_transcribe_wav"),
+        (ModulateAsyncProcessor, {}, "_transcribe_wav"),
+        (SmallestAsyncProcessor, {}, "_transcribe_wav"),
+        (SonioxAsyncProcessor, {}, "_transcribe_async"),
+    ],
+    ids=["assemblyai", "shared-cloud", "mistral", "modulate", "smallest", "soniox"],
+)
+@pytest.mark.parametrize("terminal_type", [CancelFrame, EndFrame, StopFrame])
+@pytest.mark.asyncio
+async def test_buffered_upload_requires_normal_stop(processor_type, options, transcribe_attribute, terminal_type):
+    progress = Mock()
+    processor = processor_type(api_key="test-key", session=object(), on_progress=progress, **options)
+    processor.push_frame = AsyncMock()
+    original_buffer = processor._buffer
+    pcm = b"\x01\x02" * 160
+    uploaded = []
+
+    async def transcribe(wav_source=None, *, audio_stream=None, audio_size=None):
+        if audio_stream is not None:
+            uploaded.append(audio_stream.read(audio_size))
+        else:
+            with wave.open(wav_source, "rb") as reader:
+                uploaded.append(reader.readframes(reader.getnframes()))
+        return "Final transcript."
+
+    setattr(processor, transcribe_attribute, transcribe)
+    terminal = terminal_type()
+    direction = FrameDirection.DOWNSTREAM
+    try:
+        await processor.process_frame(InputAudioRawFrame(audio=pcm, sample_rate=16000, num_channels=1), direction)
+        await processor.process_frame(terminal, direction)
+        # A repeated stop must not recover or resubmit the discarded recording.
+        await processor.process_frame(EndFrame(), direction)
+        frames = [call.args[0] for call in processor.push_frame.call_args_list]
+        assert original_buffer.closed and processor._buffer_size == 0
+        assert sum(frame is terminal for frame in frames) == 1
+        assert not any(isinstance(frame, ErrorFrame) for frame in frames)
+        finals = [frame.text for frame in frames if isinstance(frame, TranscriptionFrame)]
+        if terminal_type is CancelFrame:
+            assert uploaded == [], "Cancel must discard captured audio before any provider upload"
+            assert finals == []
+            progress.assert_not_called()
+        else:
+            assert uploaded == [pcm]
+            assert finals == ["Final transcript."]
+    finally:
+        processor._buffer.close()
+
+
+@pytest.mark.asyncio
+async def test_shared_cloud_cancel_releases_capture_wav_without_opening_or_uploading():
+    processor = SpeechmaticsAsyncProcessor(api_key="test-key", language="de", session=object())
+    processor.push_frame = AsyncMock()
+    processor._transcribe_wav = AsyncMock(return_value="Canceled transcript.")
+    artifact = Mock()
+    artifact.open_async = AsyncMock(return_value=Mock(spec=["close"]))
+    artifact.release_async = AsyncMock()
+    assert processor.adopt_capture_wav_artifact(artifact)
+    direction = FrameDirection.DOWNSTREAM
+    try:
+        await processor.process_frame(
+            InputAudioRawFrame(audio=b"\x01\x02" * 160, sample_rate=16000, num_channels=1), direction
+        )
+        await processor.process_frame(CancelFrame(), direction)
+        artifact.open_async.assert_not_awaited()
+        artifact.release_async.assert_awaited_once()
+        processor._transcribe_wav.assert_not_awaited()
+        assert not processor.adopt_capture_wav_artifact(artifact)
+    finally:
+        processor._buffer.close()

--- a/tests/test_database_search.py
+++ b/tests/test_database_search.py
@@ -32,6 +32,29 @@ def test_fts_query_preserves_unicode_words():
     assert _search_count("Grüße aus München", "München") == 1
 
 
+def test_punctuation_search_treats_sql_wildcards_as_literal_text(monkeypatch, tmp_path):
+    database._close_all_connections()
+    monkeypatch.setattr(database, "_DB_PATH", tmp_path / "transcripts.db")
+    try:
+        database.init_database()
+        for record_id, content in (
+            ("percentage", "Margin improved by 10%."),
+            ("unrelated", "The next meeting is on Friday."),
+        ):
+            database.save_transcript(
+                {"id": record_id, "title": record_id, "status": "completed", "type": "file", "content": content}
+            )
+
+        result = database.search_transcript_metadata("%", transcript_type="file", limit=1)
+
+        assert result["total"] == 1
+        assert [item["id"] for item in result["items"]] == ["percentage"]
+        assert result["hasMore"] is False
+        assert database.search_transcript_metadata("%%")["total"] == 0
+    finally:
+        database._close_all_connections()
+
+
 def test_save_transcript_propagates_storage_failure(monkeypatch):
     class _FailingConnection:
         def __enter__(self):

--- a/tests/test_meeting_export.py
+++ b/tests/test_meeting_export.py
@@ -4,12 +4,15 @@ import copy
 from email import policy
 from email.parser import BytesParser
 
+import pytest
+
 from src.meeting_export import (
     build_eml_draft,
     build_meeting_email,
     build_meeting_markdown,
     build_meeting_summary_markdown,
     build_meeting_transcript_text,
+    meeting_duration_ms,
     meeting_email_recipients,
     meeting_export_labels,
     meeting_export_language,
@@ -133,6 +136,32 @@ def test_meeting_templates_keep_summary_and_timestamped_transcript_distinct():
     assert "**Duration:** 0:08" in markdown
     assert "### 0:01 → 0:04 · Alex" in markdown
     assert markdown.count("# Roadmap review") == 1
+
+
+@pytest.mark.parametrize("include_segments", [True, False])
+def test_meeting_export_duration_preserves_silence_in_retained_recording(include_segments):
+    detail = meeting_detail()
+    if not include_segments:
+        detail["segments"] = []
+    detail["audioAssets"] = [
+        {"kind": "playback_microphone", "durationMs": 90_000},
+        {
+            "kind": "playback_mix",
+            "durationMs": 30_000,
+            "trackManifest": [{"source": "mixed", "timelineOriginMs": 2_000}],
+        },
+    ]
+
+    assert meeting_duration_ms(detail) == 32_000
+    assert "**Duration:** 0:32" in build_meeting_markdown(detail)
+    assert "Duration: 0:32" in build_meeting_email(detail)["body"]
+
+
+def test_meeting_export_duration_falls_back_to_segments_without_retained_mix():
+    detail = meeting_detail()
+    detail["audioAssets"] = [{"kind": "playback_microphone", "durationMs": 90_000}]
+
+    assert meeting_duration_ms(detail) == 8_250
 
 
 def test_email_template_uses_unique_valid_outlook_participants_without_false_attachment_claim():

--- a/tests/test_pipeline_stop.py
+++ b/tests/test_pipeline_stop.py
@@ -11,9 +11,11 @@ from unittest.mock import AsyncMock
 
 import pytest
 from pipecat.frames.frames import (
+    CancelFrame,
     EndFrame,
     InputAudioRawFrame,
     StartFrame,
+    StopFrame,
     TranscriptionFrame,
     VADUserStartedSpeakingFrame,
     VADUserStoppedSpeakingFrame,
@@ -2965,7 +2967,8 @@ async def test_live_vad_finalization_flushes_when_hotkey_stops_during_speech():
 
 
 @pytest.mark.asyncio
-async def test_segmented_stt_gate_defaults_to_whole_recording_segment():
+@pytest.mark.parametrize("terminal_frame", [EndFrame, StopFrame])
+async def test_segmented_stt_gate_defaults_to_whole_recording_segment(terminal_frame):
     gate = SegmentedSTTRecordingGate(vad_segmentation_enabled=False)
     pushed = []
 
@@ -2976,13 +2979,35 @@ async def test_segmented_stt_gate_defaults_to_whole_recording_segment():
 
     await gate.process_frame(VADUserStartedSpeakingFrame(), FrameDirection.DOWNSTREAM)
     await gate.process_frame(VADUserStoppedSpeakingFrame(), FrameDirection.DOWNSTREAM)
-    await gate.process_frame(EndFrame(), FrameDirection.DOWNSTREAM)
+    await gate.process_frame(terminal_frame(), FrameDirection.DOWNSTREAM)
 
     assert pushed == [
         (VADUserStartedSpeakingFrame, FrameDirection.DOWNSTREAM),
         (VADUserStoppedSpeakingFrame, FrameDirection.DOWNSTREAM),
-        (EndFrame, FrameDirection.DOWNSTREAM),
+        (terminal_frame, FrameDirection.DOWNSTREAM),
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("vad_enabled", [False, True])
+async def test_segmented_stt_gate_cancel_never_commits_buffered_speech(vad_enabled):
+    gate = SegmentedSTTRecordingGate(vad_segmentation_enabled=vad_enabled)
+    gate.push_frame = AsyncMock()
+    await gate.process_frame(VADUserStartedSpeakingFrame(), FrameDirection.DOWNSTREAM)
+    await gate.process_frame(
+        InputAudioRawFrame(audio=b"\x01\x00" * 1600, sample_rate=16000, num_channels=1),
+        FrameDirection.DOWNSTREAM,
+    )
+    gate.push_frame.reset_mock()
+
+    cancel = CancelFrame()
+    await gate.process_frame(cancel, FrameDirection.DOWNSTREAM)
+
+    # A VAD stop tells segmented providers to upload the buffered recording.
+    # Cancellation must discard that boundary, including a later cleanup flush.
+    gate.push_frame.assert_awaited_once_with(cancel, FrameDirection.DOWNSTREAM)
+    assert await gate.flush_segment() is False
+    gate.push_frame.assert_awaited_once_with(cancel, FrameDirection.DOWNSTREAM)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Scriber could upload canceled recordings, lose a reverted Meeting note during shutdown, truncate exported Meeting duration, and return unrelated history entries for a percent-sign search.

## Fixes

- Discard buffered audio on `CancelFrame` across the shared cloud adapter, AssemblyAI, Mistral, Modulate, Smallest, and Soniox. Release adopted Rust WAV artifacts without opening or uploading them. Close recording-gate state without emitting a VAD stop that would commit canceled audio. Normal End/Stop finalization still runs once.
- Compare Meeting note teardown saves against the newest effective write generation, preserving user reverts even when older autosaves or newer teardown requests are in flight.
- Use the retained playback mix's full duration and Meeting-clock origin for exports, including trailing silence; retain segment-time fallback when playback duration is unavailable.
- Treat punctuation-only history queries as literal substrings so `%` cannot act as a SQL wildcard.

Each failure was reproduced against the original implementation before applying the fix. Changes are split into four commits, with durable contracts updated in AGENTS.md.

## Validation

All six Hybrid PR Checks passed for final head `109fa074744f4994344f3a7bd5a423a6ab2a36a2`.

- Windows Python full suite: **4,247 passed, 5 skipped**.
- Rust: **303 passed**; formatting and Clippy passed.
- Frontend: **109 library tests and 66 component tests passed**; application/test TypeScript checks, ESLint, and production build passed.
- Real-browser File upload smoke passed against React/Vite and the production Python application composition.
- Extended Python mypy: no issues in **77 source files**.
- Repository-wide Python Ruff, focused hybrid gates, QuickJS cache verification, and GitHub Actions syntax passed.
- Independent review found no blocking correctness issues. The configured Codex reviewer left a thumbs-up; no open review threads remain.
- Published Git tree hashes match the locally validated trees exactly.

The five Python skips concern optional locked QuickJS/FFmpeg and shipping-native-runtime qualification conditions. Provider regressions use local PCM and controlled upload callbacks; no live provider calls, physical microphone tests, installed-app smoke, installer build, or release were performed. The browser smoke ends at the durable queued-job boundary.

## CI evidence

1. [https://github.com/MyButtermilk/Scriber/actions/runs/33949478175](https://github.com/MyButtermilk/Scriber/actions/runs/33949478175)
